### PR TITLE
Style link, and inline styles for performance

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -10,6 +10,8 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Displays a banner and link on your site to show your support for Ukraine.
 
+Styles are output inline for performance reasons, but can be filtered using the `swu_banner_styles` filter hook should you wish to customise them.
+
 == Description ==
 
 Displays a banner on your site to show your support for Ukraine. Customize your banner using the #stand_with_ukraine_overlay id attribute.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: standwithukraine
 Requires at least: 4.5
 Tested up to: 5.9.1
 Requires PHP: 5.6
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -15,6 +15,10 @@ Displays a banner and link on your site to show your support for Ukraine.
 Displays a banner on your site to show your support for Ukraine. Customize your banner using the #stand_with_ukraine_overlay id attribute.
 
 == Changelog ==
+
+= 1.0.3 =
+* Improved link styles
+* Inline CSS for performance
 
 = 1.0.2 =
 * Change: usage of jQuery, not longer necessary

--- a/stand-with-ukraine.php
+++ b/stand-with-ukraine.php
@@ -30,7 +30,7 @@ function swu_enqueue_script( $hook ) {
 
 add_action( 'wp_head', 'swu_output_css' );
 function swu_output_css() {
-	echo '
+	echo apply_filters( 'swu_banner_styles', '
 		<style>
 			#stand_with_ukraine_overlay {
 				border: 10px solid #0057B8;
@@ -52,5 +52,5 @@ function swu_output_css() {
 				text-decoration: underline;
 			}
 		</style>
-	';
+	' );
 }

--- a/stand-with-ukraine.php
+++ b/stand-with-ukraine.php
@@ -26,12 +26,31 @@ function swu_enqueue_script( $hook ) {
 		true
 	);
 	wp_enqueue_script( 'stand-with-ukraine' );
-	wp_register_style(
-		'stand-with-ukraine',
-		SWU_PLUGIN_URL . 'stand_with_ukraine.css',
-		array(),
-		'1.0.0',
-		'all'
-	);
-	wp_enqueue_style( 'stand-with-ukraine' );
+}
+
+add_action( 'wp_head', 'swu_output_css' );
+function swu_output_css() {
+	echo '
+		<style>
+			#stand_with_ukraine_overlay {
+				border: 10px solid #0057B8;
+				padding: 5px;
+				text-align: center;
+				text-combine: #0057B8;
+				background-color: #FFD700;
+				margin-bottom: 8px;
+			}
+			#stand_with_ukraine_overlay a {
+				display: inline-block;
+				padding: 3px 6px;
+				color: #0057B8;
+				text-decoration: underline;
+			}
+			#stand_with_ukraine_overlay a:hover,
+			#stand_with_ukraine_overlay a:focus {
+				border: 2px #0057B8 dashed;
+				text-decoration: underline;
+			}
+		</style>
+	';
 }

--- a/stand_with_ukraine.css
+++ b/stand_with_ukraine.css
@@ -1,7 +1,0 @@
-#stand_with_ukraine_overlay {
-	border: 10px solid #0057B8;
-	padding: 5px;
-	text-align: center;
-	text-combine: #0057B8;
-	background-color: #FFD700;
-}


### PR DESCRIPTION
Resolves #4 

Previously the link inherited styles. On my site this meant little contrast.

![CleanShot 2022-03-07 at 12 35 27](https://user-images.githubusercontent.com/1532368/157035561-91baf58c-b044-4b13-9525-57fe825712f7.png)

I've styled the link in the blue, and specified an underline with a border on hover/focus.

![CleanShot 2022-03-07 at 12 36 03](https://user-images.githubusercontent.com/1532368/157035658-29373e87-e9ef-45c0-a1b0-331e74d0e31c.png)

![CleanShot 2022-03-07 at 12 37 18](https://user-images.githubusercontent.com/1532368/157035883-3059dd17-2cc0-479b-a12d-e91424e34b9d.png)

As this is a banner that's above-the-fold, the styles should be inline to prevent the CSS being a render-blocking resource. So I've done this too.

Feel free to modify any of the style changes, but I think nudges it in the right direction.