### PR TITLE
i18n

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Stand With Ukraine ===
 Contributors: psykro, alpipego, bueltge, magicroundabout
 Tags: standwithukraine
-Requires at least: 4.5
-Tested up to: 5.9.1
+Requires at least: 4.6
+Tested up to: 5.9
 Requires PHP: 5.6
 Stable tag: 1.0.4
 License: GPLv2 or later


### PR DESCRIPTION
From 4.6, no need to add a load_plugin_textdomain()
I hope it will solve the non translatable on https://translate.wordpress.org/projects/wp-plugins/stand-with-ukraine/
I use @casiepa tool located at http://wp-info.org/tools/checkplugini18n.php?slug=stand-with-ukraine