### PR TITLE
License note and Typo

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Styles are output inline for performance reasons, but can be filtered using the 
 
 == Description ==
 
-Displays a banner on your site to show your support for Ukraine. Customize your banner using the #stand_with_ukraine_overlay id attribute.
+Displays a banner on your site to show your support for Ukraine. Customize your banner using the `#stand_with_ukraine_overlay` CSS ID-attribute.
 
 == Changelog ==
 

--- a/stand-with-ukraine.php
+++ b/stand-with-ukraine.php
@@ -4,6 +4,7 @@
  * Description:     Displays a banner on your site to show your support for Ukraine.
  * Version:         1.0.4
  * Text Domain:     stand-with-ukraine
+ * License:         GPLv2 or later
  *
  * @package         Stand_With_Ukraine
  */


### PR DESCRIPTION
Small changes for the validation at wp.org for a license, validation also at the main PHP file necessary, at the plugin metadata.
And small formatting to identify the CSS ID possibility.