### PR TITLE
removes the event listener

### DIFF
--- a/stand_with_ukraine.js
+++ b/stand_with_ukraine.js
@@ -1,7 +1,5 @@
-document.addEventListener('DOMContentLoaded', function() {
-	let body = document.getElementsByTagName('body')[0];
-	let div  = document.createElement('div');
-	div.id = 'stand_with_ukraine_overlay';
-	div.innerHTML = '<a title="' + swu_options.text + '" href="' + swu_options.url + '">' + swu_options.hashtag + '</a>';
-	document.body.insertBefore(div, body.firstChild);
-});
+/* global swu_options */
+var div  = document.createElement('div');
+div.id = 'stand_with_ukraine_overlay';
+div.innerHTML = '<a title="' + swu_options.text + '" href="' + swu_options.url + '">' + swu_options.hashtag + '</a>';
+document.body.insertAdjacentElement('afterbegin', div);


### PR DESCRIPTION
I believe there is no need to wait for the DOM to be loaded in order to run the script as document.body is already part of the DOM model. This could avoid a CLS issue on websites where scripts run very late

https://html.spec.whatwg.org/multipage/dom.html#dom-document-body-dev